### PR TITLE
Sub Entities. Yes please!

### DIFF
--- a/components/activity-collection/editor/d2l-activity-collection-editor-lp.js
+++ b/components/activity-collection/editor/d2l-activity-collection-editor-lp.js
@@ -1,18 +1,17 @@
 import '@brightspace-ui/core/components/list/list.js';
-import '../../activity/item/d2l-activity-item.js';
-import '../../common/d2l-hm-description.js';
+import '@brightspace-ui/core/components/list/list-item.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { HypermediaLitMixin, observableTypes} from '../../../framework/hypermedia-lit-mixin.js';
 
 const rels = Object.freeze({
-	specialization: 'https://api.brightspace.com/rels/specialization',
+	collection: 'https://activities.api.brightspace.com/rels/activity-collection',
 	item: 'item'
 });
 
 class CollectionEditor extends HypermediaLitMixin(LitElement) {
 	static get properties() {
 		return {
-			items: { type: Array, observable: observableTypes.subEntities, rel: rels.item }
+			items: { type: Array, observable: observableTypes.subEntities, rel: rels.item, route: [{observable: observableTypes.link, rel: rels.collection}] }
 		};
 	}
 
@@ -28,10 +27,10 @@ class CollectionEditor extends HypermediaLitMixin(LitElement) {
 	render() {
 		return html`
 			<d2l-list>
-				${this.items.map(href => html`<d2l-activity-item href="${href}" .token="${this.token}"></d2l-activity-item>`)}
+				${this.items.map(href => html`<d2l-list-item>${href}</d2l-list-item>`)}
 			</d2l-list>
 		`;
 	}
 
 }
-customElements.define('d2l-activity-collection-editor', CollectionEditor);
+customElements.define('d2l-activity-collection-editor-lp', CollectionEditor);

--- a/components/activity/editor/d2l-acitivity-editor-main-lp.js
+++ b/components/activity/editor/d2l-acitivity-editor-main-lp.js
@@ -1,3 +1,4 @@
+import '../../activity-collection/editor/d2l-activity-collection-editor-lp.js';
 import { customHypermediaElement, html } from '../../../framework/hypermedia-components.js';
 import { HypermediaLitMixin } from '../../../framework/hypermedia-lit-mixin.js';
 import { LitElement } from 'lit-element/lit-element.js';
@@ -6,7 +7,7 @@ class ActivityEditorMainLP extends HypermediaLitMixin(LitElement) {
 
 	render() {
 		return html`
-			ANOTHER MAIN
+			<d2l-activity-collection-editor-lp href="${this.href}" .token="${this.token}"></d2l-activity-collection-editor-lp>
 		`;
 	}
 }

--- a/components/activity/editor/d2l-activity-editor-header.js
+++ b/components/activity/editor/d2l-activity-editor-header.js
@@ -3,7 +3,6 @@ import '../name/d2l-activity-name.js';
 import { css, LitElement } from 'lit-element/lit-element.js';
 import { html } from '../../../framework/hypermedia-components.js';
 import { HypermediaLitMixin } from '../../../framework/hypermedia-lit-mixin.js';
-import { ifDefined } from 'lit-html/directives/if-defined.js';
 
 class ActivityEditorHeader extends HypermediaLitMixin(LitElement) {
 
@@ -34,9 +33,9 @@ class ActivityEditorHeader extends HypermediaLitMixin(LitElement) {
 		return html`
 			<div class="d2l-heading-4 d2l-activity-sub-header">${this.subTitle}</div>
 			<h1 class="d2l-heading-1">
-				<d2l-activity-name href="${ifDefined(this.href)}" .token="${this.token}"></d2l-activity-name>
+				<d2l-activity-name href="${this.href}" .token="${this.token}"></d2l-activity-name>
 			</h1>
-			<d2l-activity-description href="${ifDefined(this.href)}" .token="${this.token}"></d2l-activity-description>
+			<d2l-activity-description href="${this.href}" .token="${this.token}"></d2l-activity-description>
 		`;
 	}
 }

--- a/components/activity/editor/d2l-activity-editor.js
+++ b/components/activity/editor/d2l-activity-editor.js
@@ -6,7 +6,6 @@ import './d2l-activity-editor-main.js';
 import './d2l-activity-editor-sidebar.js';
 import { css, LitElement } from 'lit-element/lit-element.js';
 import { html } from '../../../framework/hypermedia-components.js';
-import { ifDefined } from 'lit-html/directives/if-defined.js';
 
 class ActivityEditor extends LitElement {
 	static get properties() {
@@ -59,10 +58,10 @@ class ActivityEditor extends LitElement {
 	_renderDefault() {
 		return html`
 			<div class="d2l-activity-editor-template-default">
-				<d2l-activity-editor-header href="${ifDefined(this.href)}" .token="${this.token}"></d2l-activity-editor-header>
-				<d2l-activity-editor-main href="${ifDefined(this.href)}" .token="${this.token}"></d2l-activity-editor-main>
+				<d2l-activity-editor-header href="${this.href}" .token="${this.token}"></d2l-activity-editor-header>
+				<d2l-activity-editor-main href="${this.href}" .token="${this.token}"></d2l-activity-editor-main>
 				<d2l-floating-buttons always-float>
-					<d2l-activity-editor-footer href="${ifDefined(this.href)}" .token="${this.token}"></d2l-activity-editor-footer>
+					<d2l-activity-editor-footer href="${this.href}" .token="${this.token}"></d2l-activity-editor-footer>
 				</d2l-floating-buttons>
 			</div>
 		`;
@@ -72,11 +71,11 @@ class ActivityEditor extends LitElement {
 		return html`
 			<d2l-template-primary-secondary>
 				<slot name="editor-nav" slot="header"></slot>
-				<d2l-activity-editor-header slot="primary" href="${ifDefined(this.href)}" .token="${this.token}"></d2l-activity-editor-header>
-				<d2l-activity-editor-main slot="primary" href="${ifDefined(this.href)}" .token="${this.token}"></d2l-activity-editor-main>
-				<d2l-activity-editor-sidebar slot="secondary" href="${ifDefined(this.href)}" .token="${this.token}"></d2l-activity-editor-sidebar>
+				<d2l-activity-editor-header slot="primary" href="${this.href}" .token="${this.token}"></d2l-activity-editor-header>
+				<d2l-activity-editor-main slot="primary" href="${this.href}" .token="${this.token}"></d2l-activity-editor-main>
+				<d2l-activity-editor-sidebar slot="secondary" href="${this.href}" .token="${this.token}"></d2l-activity-editor-sidebar>
 				<div slot="footer">
-					<d2l-activity-editor-footer href="${ifDefined(this.href)}" .token="${this.token}"></d2l-activity-editor-footer>
+					<d2l-activity-editor-footer href="${this.href}" .token="${this.token}"></d2l-activity-editor-footer>
 				</div>
 			</d2l-template-primary-secondary>
 		`;

--- a/framework/hypermedia-components.js
+++ b/framework/hypermedia-components.js
@@ -5,6 +5,7 @@ import { observableTypes } from '../state/HypermediaState.js';
 import { until } from 'lit-html/directives/until.js';
 
 export function customHypermediaElement(tag, elementClass, pseudoTag, hypermediaClasses, options) {
+	pseudoTag = pseudoTag || tag;
 	const components = componentStoreFactory(pseudoTag);
 	components.register(tag, hypermediaClasses);
 	customElements.define(tag, elementClass, options);
@@ -46,8 +47,14 @@ export function html(strings, ...values) {
 		});
 
 		currentCollection.strings.push(currentString);
-		currentValue && currentCollection.values.push(currentValue);
+		currentCollection.values.push(currentValue);
 	}
+
+	//todo: this solves the token ifDefined issue. But really? Shouldn't there be a real way to fix it? I think so.
+	while (stringCollections[0].strings.length <= stringCollections[0].values.length && stringCollections[0].values.length !== 0) {
+		stringCollections[0].values.pop();
+	}
+
 	return new TemplateResult(stringCollections[0].strings, stringCollections[0].values, 'html', defaultTemplateProcessor);
 }
 

--- a/framework/hypermedia-lit-mixin.js
+++ b/framework/hypermedia-lit-mixin.js
@@ -26,12 +26,11 @@ export const HypermediaLitMixin = superclass => class extends superclass {
 	}
 
 	updated(changedProperties) {
-		if ((changedProperties.has('href') || changedProperties.has('token')) &&
-			this.href && this.token) {
-			dispose(this._state);
+		if ((changedProperties.has('href') || changedProperties.has('token')) && this.href && this.token) {
+			dispose(this._state, this);
 			this._makeState();
 		}
-		super.updated();
+		super.updated(changedProperties);
 	}
 
 	connectedCallback() {
@@ -42,7 +41,7 @@ export const HypermediaLitMixin = superclass => class extends superclass {
 	}
 
 	disconnectedCallback() {
-		dispose(this._state);
+		dispose(this._state, this);
 		super.disconnectedCallback();
 	}
 

--- a/state/HypermediaState.js
+++ b/state/HypermediaState.js
@@ -1,13 +1,7 @@
-import { sirenComponentBasicInfo, sirenComponentFactory } from './sirenComponents/sirenComponentFactory.js';
+import { observableTypes as ot, sirenComponentBasicInfo, sirenComponentFactory } from './sirenComponents/sirenComponentFactory.js';
 import { refreshToken } from './token.js';
 
-export const observableTypes = Object.freeze({
-	property: 1,
-	link: 2,
-	classes: 3,
-	subEntities: 4,
-	entity: 5
-});
+export const observableTypes = ot;
 
 /**
  *
@@ -40,7 +34,7 @@ export class HypermediaState {
 
 			const basicInfo = sirenComponentBasicInfo(propertyInfo);
 			const sirenComponent = this._getSirenComponent(basicInfo);
-			sirenComponent.addComponent(component, name, basicInfo.route ? {[name]: basicInfo.route} : undefined);
+			sirenComponent.addComponent(component, name, { route: basicInfo.route ? {[name]: basicInfo.route} : undefined, method: observables[name].method });
 		});
 	}
 

--- a/state/HypermediaState.js
+++ b/state/HypermediaState.js
@@ -33,6 +33,8 @@ export class HypermediaState {
 			};
 
 			const basicInfo = sirenComponentBasicInfo(propertyInfo);
+			if (!basicInfo) return;
+
 			const sirenComponent = this._getSirenComponent(basicInfo);
 			sirenComponent.addComponent(component, name, { route: basicInfo.route ? {[name]: basicInfo.route} : undefined, method: observables[name].method });
 		});

--- a/state/sirenComponents/Common.js
+++ b/state/sirenComponents/Common.js
@@ -1,22 +1,25 @@
 export class Component {
 	constructor() {
 		this._components = new Map();
+		this._methods = new WeakMap();
 	}
 
 	get components() {
 		return this._components;
 	}
 
-	add(component, property) {
+	add(component, property, method) {
 		if (this._components.has(component)) {
 			return;
 		}
 		this._components.set(component, property);
+		method && this._methods.set(component, method);
 	}
 
 	setProperty(value) {
 		this._components.forEach((property, component) => {
-			component[property] = value;
+			const method = this._methods.has(component) && this._methods.get(component);
+			component[property] = method ? method(value) : value;
 		});
 	}
 
@@ -24,12 +27,19 @@ export class Component {
 		if (!this._components.has(component)) {
 			return false;
 		}
+		const method = this._methods.has(component) && this._methods.get(component);
 
-		component[this._components.get(component)] = value;
+		component[this._components.get(component)] = method ? method(value) : value;
 	}
 
 	delete(component) {
+		this._methods.delete(component);
 		return this._components.delete(component);
 	}
 
+}
+
+export function getEntityIdFromSirenEntity(entity) {
+	const self = entity.hasLinkByRel && entity.hasLinkByRel('self') && entity.getLinkByRel && entity.getLinkByRel('self');
+	return  entity.href || (self && self.href);
 }

--- a/state/sirenComponents/SirenClasses.js
+++ b/state/sirenComponents/SirenClasses.js
@@ -17,8 +17,8 @@ export class SirenClasses {
 
 	}
 
-	addComponent(component, property) {
-		this._components.add(component, property);
+	addComponent(component, property, {method}) {
+		this._components.add(component, property, method);
 		this._components.setComponentProperty(component, this.value);
 	}
 

--- a/state/sirenComponents/SirenEntity.js
+++ b/state/sirenComponents/SirenEntity.js
@@ -16,8 +16,8 @@ export class SirenEntity {
 		this._sirenEntity = sirenEntity;
 	}
 
-	addComponent(component, property) {
-		this._components.add(component, property);
+	addComponent(component, property, {method}) {
+		this._components.add(component, property, method);
 		this._components.setComponentProperty(component, this.sirenEntity);
 	}
 

--- a/state/sirenComponents/SirenLink.js
+++ b/state/sirenComponents/SirenLink.js
@@ -30,12 +30,12 @@ export class SirenLink {
 		return this._rel;
 	}
 
-	addComponent(component, property, route) {
+	addComponent(component, property, {route, method}) {
 		if (route) {
 			this._routes.set(component, route);
 			return;
 		}
-		this._components.add(component, property);
+		this._components.add(component, property, method);
 		this._components.setComponentProperty(component, this.link && this.link.href);
 	}
 

--- a/state/sirenComponents/SirenProperty.js
+++ b/state/sirenComponents/SirenProperty.js
@@ -27,8 +27,8 @@ export class SirenProperty {
 		return this._property;
 	}
 
-	addComponent(component, property) {
-		this._components.add(component, property);
+	addComponent(component, property, {method}) {
+		this._components.add(component, property, method);
 		this._components.setComponentProperty(component, this.value);
 	}
 

--- a/state/sirenComponents/SirenSubEntities.js
+++ b/state/sirenComponents/SirenSubEntities.js
@@ -1,0 +1,86 @@
+import { Component, getEntityIdFromSirenEntity } from './Common.js';
+import { SirenSubEntity } from './SirenSubEntity.js';
+
+export class SirenSubEntities {
+	static basicInfo({token}) {
+		return { token };
+	}
+
+	constructor({id, token}) {
+		this._rel = id;
+		this._childSubEntities = new Map();
+		this._components = new Component();
+		this._token = token;
+		this._entityIds = [];
+	}
+
+	get entityIds() {
+		return this._entityIds;
+	}
+
+	set entityIds(entityIds) {
+		if (!this._entityId !== entityIds) {
+			this._components.setProperty(entityIds || []);
+		}
+		this._entityIds = entityIds || [];
+	}
+
+	get rel() {
+		return this._rel;
+	}
+
+	get childSubEntities() {
+		return this._childSubEntities;
+	}
+
+	addComponent(component, property, {method}) {
+		this._components.add(component, property, method);
+		this._components.setComponentProperty(component, this.entityIds);
+	}
+
+	deleteComponent(component) {
+		if (this._route.has(component)) {
+			this._childState.dispose(component);
+			this._route.delete(component);
+			return;
+		}
+		this._components.delete(component);
+	}
+
+	setSirenEntity(sirenEntity) {
+		const subEntities = sirenEntity && sirenEntity.getSubEntitiesByRel(this._rel);
+		const childSubEntities = new Map();
+
+		// This makes the assumption that the order returned by the collection
+		// matches the prev/next order for each item.
+		// As of writting this making this assumption makes sense for all cases.
+		// If we find a case where that assumption is bad.
+		// There is a way to build a list from next/prev that is performant
+		// and will change based on the individual item update.
+		subEntities.forEach((sirenSubEntity) => {
+			const entityId = getEntityIdFromSirenEntity(sirenSubEntity);
+			// If we already set it up why do it again?
+			if (this.childSubEntities.has(entityId)) {
+				childSubEntities.set(entityId, this.childSubEntities.get(entityId));
+				this.childSubEntities.delete(entityId);
+				return;
+			}
+
+			const subEntity = new SirenSubEntity({id: this.rel, token: this._token});
+			subEntity.entityId = entityId;
+			childSubEntities.set(entityId, subEntity);
+		});
+
+		// These ones are no longer required.
+		this.childSubEntities.clear();
+
+		this._childSubEntities = childSubEntities;
+
+		const entityIds = [];
+		this.childSubEntities.forEach((_, entityId) => {
+			entityIds.push(entityId);
+		});
+
+		this.entityIds = entityIds;
+	}
+}

--- a/state/sirenComponents/SirenSubEntity.js
+++ b/state/sirenComponents/SirenSubEntity.js
@@ -1,5 +1,5 @@
+import { Component, getEntityIdFromSirenEntity } from './Common.js';
 import { fetch, stateFactory } from '../../state/store.js';
-import { Component } from './Common.js';
 import { shouldAttachToken } from '../token.js';
 
 export class SirenSubEntity {
@@ -29,12 +29,12 @@ export class SirenSubEntity {
 		return this._childState;
 	}
 
-	addComponent(component, property, route) {
+	addComponent(component, property, {route, method}) {
 		if (route) {
 			this._routes.set(component, route);
 			return;
 		}
-		this._components.add(component, property);
+		this._components.add(component, property, method);
 		this._components.setComponentProperty(component, this.entityId);
 	}
 
@@ -49,10 +49,10 @@ export class SirenSubEntity {
 
 	setSirenEntity(sirenEntity, SubEntityCollectionMap) {
 		const subEntity = sirenEntity && sirenEntity.hasSubEntityByRel(this._rel) && sirenEntity.getSubEntityByRel(this._rel);
-		if (!this.link) return;
+		if (!subEntity) return;
 
 		if (SubEntityCollectionMap && SubEntityCollectionMap instanceof Map) {
-			this.link.rel.forEach(rel => {
+			subEntity.rel.forEach(rel => {
 				if (SubEntityCollectionMap.has(rel)) {
 					this._merge(SubEntityCollectionMap.get(rel));
 				}
@@ -64,7 +64,7 @@ export class SirenSubEntity {
 	}
 
 	async _setSubEntity(subEntity) {
-		this.entityId = this._getEntityIdFromSirenEntity(subEntity);
+		this.entityId = getEntityIdFromSirenEntity(subEntity);
 
 		if (this._token) {
 			this._childState = await stateFactory(this.entityId, shouldAttachToken(this._token, subEntity));
@@ -73,10 +73,5 @@ export class SirenSubEntity {
 			});
 			fetch(this._childState);
 		}
-	}
-
-	_getEntityIdFromSirenEntity(entity) {
-		const self = entity.hasLinkByRel && entity.hasLinkByRel('self') && entity.getLinkByRel && entity.getLinkByRel('self');
-		return  entity.href || (self && self.href);
 	}
 }

--- a/state/sirenComponents/sirenComponentFactory.js
+++ b/state/sirenComponents/sirenComponentFactory.js
@@ -44,7 +44,7 @@ export function sirenComponentBasicInfo(componentProperties) {
 	componentProperties = handleRouting(componentProperties);
 	const sirenComponentType = componentProperties.observable && observableClasses[componentProperties.observable];
 	if (!sirenComponentType) {
-		throw new Error('Bad siren component');
+		return;
 	}
 
 	const specailBasicInfo = sirenComponentType.basicInfo ? sirenComponentType.basicInfo(componentProperties) : {};

--- a/state/sirenComponents/sirenComponentFactory.js
+++ b/state/sirenComponents/sirenComponentFactory.js
@@ -2,6 +2,7 @@ import { SirenClasses } from './SirenClasses.js';
 import { SirenEntity } from './SirenEntity.js';
 import { SirenLink } from './SirenLink.js';
 import { SirenProperty } from './SirenProperty.js';
+import { SirenSubEntities } from './SirenSubEntities.js';
 import { SirenSubEntity } from './SirenSubEntity.js';
 
 export const observableTypes = Object.freeze({
@@ -18,7 +19,8 @@ const observableClasses = Object.freeze({
 	[observableTypes.entity]: SirenEntity,
 	[observableTypes.link]: SirenLink,
 	[observableTypes.property]: SirenProperty,
-	[observableTypes.subEntity]: SirenSubEntity
+	[observableTypes.subEntity]: SirenSubEntity,
+	[observableTypes.subEntities]: SirenSubEntities
 });
 
 function defaultBasicInfo({observable: type, prime, rel: id, route, token}) {

--- a/state/store.js
+++ b/state/store.js
@@ -194,9 +194,9 @@ window.D2L = window.D2L || {};
 window.D2L.SirenSdk = window.D2L.SirenSdk || {};
 window.D2L.SirenSdk.StateStore = window.D2L.SirenSdk.StateStore || new StateStore(window.d2lfetch);
 
-export async function refreshState(state) {
+export async function refreshState(state, refetch = true) {
 	await state.refreshToken();
-	return window.D2L.SirenSdk.StateStore.fetch(state, true);
+	return window.D2L.SirenSdk.StateStore.fetch(state, refetch);
 }
 
 export async function stateFactory(entityId, token) {
@@ -211,14 +211,11 @@ export async function fetch(state) {
 	if (!state || state.hasServerResponseCached()) {
 		return true;
 	}
+
 	await state.refreshToken();
 	return window.D2L.SirenSdk.StateStore.fetch(state);
 }
 
-export async function dispose(state) {
-	if (!state) return;
-	await state.refreshToken();
-	await state.dispose();
-	window.D2L.SirenSdk.StateStore.remove(state);
-	state = null;
+export async function dispose(state, component) {
+	state && state.dispose(component);
 }


### PR DESCRIPTION
This basically gives us the ability to pull a list of sub entities.

![image](https://user-images.githubusercontent.com/13232226/93152977-1e48ba00-f6ce-11ea-8313-1b304cca5c0d.png)

Each one is the different course items for the learning path. Once I get my split mixin for list items in we can add a course list.

Also, fixed some other issues. 
- Fixes #9 
- Fixes #10
- Fixes #11

I also added the ability to add `method` to give us more options. I ended up not needing this change yet after talking to Eric. But could be super useful. I would want the method to also send the raw siren object for more options but lets do that if we need it.